### PR TITLE
Adding drone pipeline for publishing quay image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,8 +5,7 @@ name: default
 
 trigger:
   branch:
-    #- master
-    - publish_image
+    - master
 
 steps:
   - name: test
@@ -15,7 +14,7 @@ steps:
       - go vet ./...
       - go test ./...
 
-  - name: publish
+  - name: publish_push
     image: plugins/docker
     settings:
       registry: quay.io
@@ -29,3 +28,19 @@ steps:
     when:
       event:
         - push
+
+  - name: publish_tag
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/mongodb/drone-bazelisk-ecr
+      tags:
+        - git-${DRONE_COMMIT_SHA:0:7}
+        - ${DRONE_TAG}
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+    when:
+      event:
+        - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,6 +21,7 @@ steps:
       repo: quay.io/mongodb/drone-bazelisk-ecr
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}
+        - latest
       username:
         from_secret: docker_username
       password:
@@ -37,6 +38,7 @@ steps:
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}
         - ${DRONE_TAG}
+        - latest
       username:
         from_secret: docker_username
       password:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,31 @@
+---
+kind: pipeline
+type: kubernetes
+name: default
+
+trigger:
+  branch:
+    #- master
+    - publish_image
+
+steps:
+  - name: test
+    image: golang:1.13
+    commands:
+      - go vet ./...
+      - go test ./...
+
+  - name: publish
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/mongodb/drone-bazelisk-ecr
+      tags:
+        - git-${DRONE_COMMIT_SHA:0:7}
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+    when:
+      event:
+        - push

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN groupadd -g ${BAZEL_USER_ID} -r ${BAZEL_USER} \
  && chmod +x ${ECR_LOGIN_PATH}
 
 COPY --from=plugin /go/bin/drone-bazelisk-ecr /usr/local/bin/drone-bazelisk-ecr
-COPY --chown=${BAZEL_USER}:${BAZEL_USER} files/config.json ${BAZEL_USER_HOME}/.docker/config.json
+COPY --chown=bazel:bazel files/config.json ${BAZEL_USER_HOME}/.docker/config.json
 
 USER ${BAZEL_USER}
 ENTRYPOINT ["drone-bazelisk-ecr"]


### PR DESCRIPTION
cc: @dskatz @redondos @richerve

This also includes a fix for the `--chown` directive which doesn't support variable expansion until docker 19.03.

An initial image has already been published from master:

    docker pull quay.io/mongodb/drone-bazelisk-ecr