### PR TITLE
Set git safe directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN wget -qO ${BAZELISK_PATH} https://github.com/bazelbuild/bazelisk/releases/do
 
 COPY --from=plugin /go/bin/drone-bazelisk-ecr /usr/local/bin/drone-bazelisk-ecr
 COPY --chown=bazel:bazel files/config.json ${BAZEL_USER_HOME}/.docker/config.json
+COPY --chown=bazel:bazel files/gitconfig ${BAZEL_USER_HOME}/.gitconfig
 
 USER ${BAZEL_USER}
 ENTRYPOINT ["drone-bazelisk-ecr"]

--- a/files/gitconfig
+++ b/files/gitconfig
@@ -1,0 +1,2 @@
+[safe]
+	directory = *


### PR DESCRIPTION
This PR is trying to address https://github.com/kanopy-platform/drone-bazelisk-ecr/issues/10.

This sets /drone/src as a global safe directory via git config in the bazel user home per [git safe directory configuration reference](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory).

I validated that git respects the change with a container image that copied a shallow cloned repository owned by root to both /drone/src and /notdrone/src a bazel build from this these commits.

```
bazel@5524fe8e3b96:/drone/src$ pwd
/drone/src
bazel@5524fe8e3b96:/drone/src$ ls -l
total 36
-rw-r--r-- 1 root root  490 May  9 20:59 BUILD
-rw-r--r-- 1 root root  536 May 10 14:19 Dockerfile
-rw-r--r-- 1 root root  714 May 10 13:51 README.md
-rw-r--r-- 1 root root  956 May  9 20:59 WORKSPACE
-rw-r--r-- 1 root root  276 May 10 13:51 crossplane.yaml
-rw-r--r-- 1 root root  736 May 10 13:51 donothing.yaml
-rwxr-xr-x 1 root root  154 May 10 13:51 gather.bash
drwxr-xr-x 2 root root 4096 May 10 13:58 scripts
-rw-r--r-- 1 root root   69 May  9 21:09 secerts.env
bazel@5524fe8e3b96:/drone/src$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   Dockerfile

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        .bazelrc
        .bazelrc.drone
        .bazelversion
        .drone.yml
        BUILD
        WORKSPACE
        scripts/
        secerts.env

no changes added to commit (use "git add" and/or "git commit -a")
bazel@5524fe8e3b96:/drone/src$ cd /notdrone/src/
bazel@5524fe8e3b96:/notdrone/src$ pwd
/notdrone/src
bazel@5524fe8e3b96:/notdrone/src$ ls -l
total 36
-rw-r--r-- 1 root root  490 May  9 20:59 BUILD
-rw-r--r-- 1 root root  536 May 10 14:19 Dockerfile
-rw-r--r-- 1 root root  714 May 10 14:19 README.md
-rw-r--r-- 1 root root  956 May  9 20:59 WORKSPACE
-rw-r--r-- 1 root root  276 May 10 14:19 crossplane.yaml
-rw-r--r-- 1 root root  736 May 10 14:19 donothing.yaml
-rwxr-xr-x 1 root root  154 May 10 14:19 gather.bash
drwxr-xr-x 2 root root 4096 May 10 13:58 scripts
-rw-r--r-- 1 root root   69 May  9 21:09 secerts.env
bazel@5524fe8e3b96:/notdrone/src$ git status
fatal: detected dubious ownership in repository at '/notdrone/src'
To add an exception for this directory, call:

        git config --global --add safe.directory /notdrone/src
```
