### PR TITLE
add engflow BES keywords for CI

### DIFF
--- a/cmd/drone-bazelisk-ecr/plugin.go
+++ b/cmd/drone-bazelisk-ecr/plugin.go
@@ -26,7 +26,7 @@ type plugin struct {
 	Bazelrc            string
 	Command            string
 	CommandArgs        string `split_words:"true"`
-	EngflowBesKeywords bool
+	EngflowBesKeywords bool `split_words:"true"`
 	TargetArgs         string `split_words:"true"`
 }
 

--- a/cmd/drone-bazelisk-ecr/plugin.go
+++ b/cmd/drone-bazelisk-ecr/plugin.go
@@ -73,11 +73,19 @@ func (p *plugin) getArgs() []string {
 		command = p.Command
 	}
 
+	args = append(args, command)
+
+	// Include step name as the CI job name for EngFlow
+	drone_step_name := os.Getenv("DRONE_STEP_NAME")
+	if drone_step_name != "" {
+		args = append(args, "--bes_keywords=engflow:CiCdJobName="+drone_step_name)
+	}
+
 	// append run and target
 	if p.CommandArgs != "" {
-		args = append(args, command, p.CommandArgs, p.Target)
+		args = append(args, p.CommandArgs, p.Target)
 	} else {
-		args = append(args, command, p.Target)
+		args = append(args, p.Target)
 	}
 
 	if p.TargetArgs != "" {

--- a/cmd/drone-bazelisk-ecr/plugin_test.go
+++ b/cmd/drone-bazelisk-ecr/plugin_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
 )
 
+type buildMock struct{}
+
+func newBuildMock() *buildMock {
+	return &buildMock{}
+}
+
+func (b *buildMock) StepName() string {
+	return "test"
+}
+
 type mockECRClient struct {
 	ecriface.ECRAPI
 }
@@ -73,7 +83,7 @@ func TestGetArgs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := test.plugin.getArgs()
+		got := test.plugin.getArgs(newBuildMock())
 		if !reflect.DeepEqual(test.want, got) {
 			t.Errorf("%v is not equal to %v", test.want, got)
 		}

--- a/cmd/drone-bazelisk-ecr/plugin_test.go
+++ b/cmd/drone-bazelisk-ecr/plugin_test.go
@@ -19,7 +19,27 @@ func newBuildMock() *buildMock {
 	return &buildMock{}
 }
 
-func (b *buildMock) StepName() string {
+func (b *buildMock) PipelineName() string {
+	return "test"
+}
+
+func (b *buildMock) JobName() string {
+	return "test"
+}
+
+func (b *buildMock) Uri() string {
+	return "test"
+}
+
+func (s *buildMock) ScmRemote() string {
+	return "test"
+}
+
+func (s *buildMock) ScmBranch() string {
+	return "test"
+}
+
+func (s *buildMock) ScmRevision() string {
 	return "test"
 }
 
@@ -79,6 +99,21 @@ func TestGetArgs(t *testing.T) {
 		{
 			plugin: plugin{Target: "test", Bazelrc: ".bazelrc.custom", TargetArgs: "--var"},
 			want:   []string{"--bazelrc=.bazelrc.custom", "run", "test", "--", "--var"},
+		},
+		{
+			plugin: plugin{Target: "test", EngflowBesKeywords: false},
+			want:   []string{"run", "test"},
+		},
+		{
+			plugin: plugin{Target: "test", EngflowBesKeywords: true},
+			want: []string{"run",
+				"--bes_keywords=engflow:CiCdPipelineName=test",
+				"--bes_keywords=engflow:CiCdJobName=test",
+				"--bes_keywords=engflow:CiCdUri=test",
+				"--bes_keywords=engflow:BuildScmRemote=test",
+				"--bes_keywords=engflow:BuildScmBranch=test",
+				"--bes_keywords=engflow:BuildScmRevision=test",
+				"test"},
 		},
 	}
 


### PR DESCRIPTION
EngFlow will be the standard remote executor/cache for Bazel, and on their build results UI they have the ability to show metadata sent by the CI system. Since this plugin is specific to Drone and EngFlow is the standard, it felt okay to tightly couple this option. Builds will work fine if it's unset. ~The alternative is every step that uses this plugin has to set command_args to this option~ it turns out this doesn't work because step name is not expanded in the YAML, it's only available as an environment variable.

We could also add all the keywords listed [see comment below] but I'm less sure if that's a good idea because it's pretty easy to do that part in a shared pipeline step. The thing that makes CiCdJobName different is that it is different for every step.